### PR TITLE
style(Dashboard): adjust image container and object-fit properties

### DIFF
--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -206,11 +206,11 @@ const Dashboard = () => {
               </div>
 
               {/* Post image */}
-              <div className="relative aspect-square w-full overflow-hidden bg-gray-200">
+              <div className="relative w-full overflow-hidden bg-gray-200 max-h-[600px]">
                 <img
                   src={post.image || "/placeholder.svg"}
                   alt={post.title}
-                  className="h-full w-full object-cover"
+                  className="w-full h-full object-contain"
                   onError={(e) => {
                     e.target.src = "/placeholder.svg"
                     e.target.onerror = null


### PR DESCRIPTION
The image container's height is now limited to a maximum of 600px to prevent excessive stretching on large images. The object-fit property is changed from 'cover' to 'contain' to ensure the entire image is visible without cropping.